### PR TITLE
Powershell script additions, VSCode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.vcs
 *.inc
+*.py
 sound.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.vcs
 *.inc
-*.py
 sound.cache

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Build Current Shader",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${workspaceFolder}/shadersrc/bin/process_shaders_single.ps1",
+            "cwd": "${workspaceFolder}/shadersrc",
+            "args": [
+                "-Version",
+                "20b",
+                "${file}"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Current Shader",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-NoLogo",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command", 
+                "bin\\process_shaders_single.ps1",
+                "-Version",
+                "20b",
+                "${file}"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            },
+            "problemMatcher": [],
+            "options": {
+                "cwd": "${workspaceFolder}/shadersrc"
+            }
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,21 +9,35 @@
                 "-NoLogo",
                 "-ExecutionPolicy",
                 "Bypass",
-                "-Command", 
+                "-Command",
                 "bin\\process_shaders_single.ps1",
                 "-Version",
                 "20b",
                 "${file}"
             ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
+            "group": "build",
             "presentation": {
                 "reveal": "always",
                 "panel": "shared"
             },
             "problemMatcher": [],
+            "options": {
+                "cwd": "${workspaceFolder}/shadersrc"
+            }
+        },
+        {
+            "label": "Build All Shaders",
+            "type": "shell",
+            "command": ".\\build_shaders.bat",
+            "args": [
+                "compile_shader_list"
+            ],
+            "problemMatcher": [],
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            },
             "options": {
                 "cwd": "${workspaceFolder}/shadersrc"
             }

--- a/README.md
+++ b/README.md
@@ -32,15 +32,22 @@ To create a new shader, copy the `template_ps2x.hlsl` file and rename it to what
 Add this new shader to the list in `compile_shader_list.txt`.
 After you run `build_shaders.bat` again, your new shader should now get compiled.
 
-Next up, you will need to create a VMT for your shader. Go into `materials/effects/shaders/` and copy the `template.vmt`, and rename it to something like `coolshader.vmt`.
-Open the VMT and change the $pixshader line to the name of your shader with a `_ps20` suffix, e.g. `coolshader_ps20`.
+Next up, you will need to copy the auto-generated VMT for your shader. Go into `materials/effects/shaders/` and copy the vmt file (e.g. `coolshader.vmt`).  You can put this file in your custom `my_shaders` folder using the same `materials/effects/shaders` file structure, or the regular game directory.
 
+## VSCode
+This repo includes a launch.json and a tasks.json to build the shaders using VSCode's build/debug commands.
+
+Clone this repository and open the main `sdk_screenspace_shaders` folder in VSCode by going to File > Open Folder.  Alternatively you can press Ctrl + K + O or Ctrl + M + O.
+
+You can now press either Ctrl + Shift + D and select "Build Current Shader".  Alternatively, press Ctrl + Shift + B to either build the current shader or all shaders (same as `build_shaders.bat`).
+
+## Applying the Shader
 Your new shader is now setup, and you can apply it to players using two methods:
 
 - `SetScriptOverlayMaterial` (only in TF2 and HL2DM): Fire the `SetScriptOverlayMaterial` input on the !activator with `effects/shaders/coolshader` parameter (or use the equivalent VScript function).
 - `r_screenoverlay` : Use a [point_clientcommand](https://developer.valvesoftware.com/wiki/point_clientcommand) and fire the `Command` input with `r_screenoverlay effects/shaders/coolshader` as the parameter on the !activator.
 
-Note: you can stack shaders across two overlays together.
+Note: in TF2 and HL2DM, you can stack shaders across two overlays together using both `SetScriptOverlayMaterial` and `r_screenoverlay`.
 
 ## Modifying the Shader
 If you are new to shaders, they are written in a language named HLSL. You can find plenty of guides about this online. This repository comes with multiple example shaders that you can reference. 

--- a/materials/effects/shaders/example_chromaticaberration.vmt
+++ b/materials/effects/shaders/example_chromaticaberration.vmt
@@ -1,0 +1,58 @@
+screenspace_general
+{
+	// Shader to use
+	// NOTE: Use '_ps20' suffix only (the engine corrects it to 'ps20b')
+	$pixshader "example_chromaticaberration_ps20"
+
+	// Textures to use
+	// Use _rt_PowerOfTwoFB to fetch the screen texture (framebuffer)
+	$basetexture "_rt_PowerOfTwoFB"
+	$texture1    ""
+	$texture2    ""
+	$texture3    ""
+
+	// Mandatory parameters, do not change these
+	$x360appchooser 1
+	$ignorez        1
+	$fix_vm         16384
+	
+	// Various color/alpha mixing parameters
+	// usually you don't need to change these
+	$copyalpha                 1
+	$alpha_blend_color_overlay 0
+	$alpha_blend               0
+	$linearwrite               0
+	$linearread_basetexture    0
+	$linearread_texture1       0
+	$linearread_texture2       0
+	$linearread_texture3       0
+
+	// 16 customizable parameters that are passed to the shader
+	$c0_x     0.0
+	$c0_y     0.0
+	$c0_z     0.0
+	$c0_w     0.0
+	$c1_x     0.0
+	$c1_y     0.0
+	$c1_z     0.0
+	$c1_w     0.0
+	$c2_x     0.0
+	$c2_y     0.0
+	$c2_z     0.0
+	$c2_w     0.0
+	$c3_x     0.0
+	$c3_y     0.0
+	$c3_z     0.0
+	$c3_w     0.0
+	
+	Proxies
+	{
+		// Fixes the viewmodel not rendering/other issues, do not remove 
+		Equals
+		{
+			srcVar1			$fix_vm
+			resultVar		$flags2
+		}
+	}
+}
+

--- a/materials/effects/shaders/example_chromaticaberration.vmt
+++ b/materials/effects/shaders/example_chromaticaberration.vmt
@@ -5,8 +5,8 @@ screenspace_general
 	$pixshader "example_chromaticaberration_ps20"
 
 	// Textures to use
-	// Use _rt_PowerOfTwoFB to fetch the screen texture (framebuffer)
-	$basetexture "_rt_PowerOfTwoFB"
+	// Use _rt_FullFrameFB to fetch the screen texture (framebuffer)
+	$basetexture "_rt_FullFrameFB"
 	$texture1    ""
 	$texture2    ""
 	$texture3    ""
@@ -14,7 +14,11 @@ screenspace_general
 	// Mandatory parameters, do not change these
 	$x360appchooser 1
 	$ignorez        1
-	$fix_vm         16384
+	$fix_fb         32768
+	"<dx90"
+	{
+		$no_draw 1
+	}
 	
 	// Various color/alpha mixing parameters
 	// usually you don't need to change these
@@ -47,10 +51,10 @@ screenspace_general
 	
 	Proxies
 	{
-		// Fixes the viewmodel not rendering/other issues, do not remove 
+		// Fixes the framebuffer to show up
 		Equals
 		{
-			srcVar1			$fix_vm
+			srcVar1			$fix_fb
 			resultVar		$flags2
 		}
 	}

--- a/shadersrc/bin/process_shaders.ps1
+++ b/shadersrc/bin/process_shaders.ps1
@@ -16,6 +16,17 @@ while ($null -ne ($line = $fileList.ReadLine())) {
 		continue
 	}
 
+	# Create a vmt file from template for each shader
+	$baseName = [System.IO.Path]::GetFileNameWithoutExtension($line) -replace "_ps2x$", ""
+	$templatePath = Join-Path $PSScriptRoot "../../../materials/effects/shaders/template.vmt"
+	$vmtPath = Join-Path $PSScriptRoot "../../../materials/effects/shaders/$baseName.vmt"
+
+	if (Test-Path $templatePath) {
+		$content = Get-Content $templatePath -Raw
+		$content = $content -replace '\$pixshader\s+"[^"]*"', "`$pixshader `"$baseName`_ps20`""
+		Set-Content -Path $vmtPath -Value $content
+	}
+
 	if ($Dynamic) {
 		& "$PSScriptRoot\ShaderCompile" "-dynamic" "-ver" $Version "-shaderpath" $File.DirectoryName $line
 		continue

--- a/shadersrc/bin/process_shaders.ps1
+++ b/shadersrc/bin/process_shaders.ps1
@@ -16,12 +16,12 @@ while ($null -ne ($line = $fileList.ReadLine())) {
 		continue
 	}
 
-	# Create a vmt file from template for each shader
+	# Create a vmt file from template for each shader if it doesn't exist
 	$baseName = [System.IO.Path]::GetFileNameWithoutExtension($line) -replace "_ps2x$", ""
 	$templatePath = Join-Path $PSScriptRoot "../../../materials/effects/shaders/template.vmt"
 	$vmtPath = Join-Path $PSScriptRoot "../../../materials/effects/shaders/$baseName.vmt"
 
-	if (Test-Path $templatePath) {
+	if ((Test-Path $templatePath) -and -not (Test-Path $vmtPath)) {
 		$content = Get-Content $templatePath -Raw
 		$content = $content -replace '\$pixshader\s+"[^"]*"', "`$pixshader `"$baseName`_ps20`""
 		Set-Content -Path $vmtPath -Value $content

--- a/shadersrc/bin/process_shaders_single.ps1
+++ b/shadersrc/bin/process_shaders_single.ps1
@@ -10,12 +10,12 @@ if ($Version -notin @("20b", "30", "40", "41", "50", "51")) {
 	return
 }
 
-# Create a vmt file from template
+# Create a vmt file from template if it doesn't exist
 $baseName = $File.BaseName -replace "_ps2x$", ""
 $templatePath = Join-Path $PSScriptRoot "../../materials/effects/shaders/template.vmt"
 $vmtPath = Join-Path $PSScriptRoot "../../materials/effects/shaders/$baseName.vmt"
 
-if (Test-Path $templatePath) {
+if ((Test-Path $templatePath) -and -not (Test-Path $vmtPath)) {
     $content = Get-Content $templatePath -Raw
     $content = $content -replace '\$pixshader\s+"[^"]*"', "`$pixshader `"$baseName`_ps20`""
     Set-Content -Path $vmtPath -Value $content

--- a/shadersrc/bin/process_shaders_single.ps1
+++ b/shadersrc/bin/process_shaders_single.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)][System.IO.FileInfo]$File,
+    [Parameter(Mandatory=$true)][string]$Version,
+    [Parameter(Mandatory=$false)][switch]$Dynamic,
+    [Parameter(Mandatory=$false)][System.UInt32]$Threads
+)
+
+if ($Version -notin @("20b", "30", "40", "41", "50", "51")) {
+	return
+}
+
+# Create a vmt file from template
+$baseName = $File.BaseName -replace "_ps2x$", ""
+$templatePath = Join-Path $PSScriptRoot "../../materials/effects/shaders/template.vmt"
+$vmtPath = Join-Path $PSScriptRoot "../../materials/effects/shaders/$baseName.vmt"
+
+if (Test-Path $templatePath) {
+    $content = Get-Content $templatePath -Raw
+    $content = $content -replace '\$pixshader\s+"[^"]*"', "`$pixshader `"$baseName`_ps20`""
+    Set-Content -Path $vmtPath -Value $content
+}
+
+if ($Dynamic) {
+	& "$PSScriptRoot\ShaderCompile" "-dynamic" "-ver" $Version "-shaderpath" $File.DirectoryName $File.Name
+	return
+}
+
+if ($Threads -ne 0) {
+	& "$PSScriptRoot\ShaderCompile" "-threads" $Threads "-ver" $Version "-shaderpath" $File.DirectoryName $File.Name
+	return
+}
+
+& "$PSScriptRoot\ShaderCompile" "-ver" $Version "-shaderpath" $File.DirectoryName $File.Name

--- a/shadersrc/compile_shader_list.txt
+++ b/shadersrc/compile_shader_list.txt
@@ -12,3 +12,4 @@ example_ascii_ps2x.hlsl
 example_square_ps2x.hlsl
 example_spin_ps2x.hlsl
 example_depth_ps2x.hlsl
+example_chromaticaberration_ps2x.hlsl

--- a/shadersrc/example_chromaticaberration_ps2x.hlsl
+++ b/shadersrc/example_chromaticaberration_ps2x.hlsl
@@ -1,0 +1,17 @@
+// Chromatic Aberration shader
+
+#include "common.hlsl"
+
+float4 main( PS_INPUT i ) : COLOR
+{
+	float2 uv = i.baseTexCoord;
+	
+    float2 d = abs((uv - 0.5) * 2.0);
+    d = pow(d, float2(2.0, 2.0));
+        
+    float4 r = tex2D(TexBase, uv - d * 0.015);
+    float4 g = tex2D(TexBase, uv);
+    float4 b = tex2D(TexBase, uv + d * 0.015);
+    
+    return float4(r.r, g.g, b.b, 1.0);
+}


### PR DESCRIPTION
1. allows VSCode users to use the built-in debug/build commands (Ctrl + Shift + D and Ctrl + Shift + B by default) to build the current HLSL file.  
Need to open the root directory in VSCode using Ctrl + K + O or Ctrl + M + O for this to work.

2. .vmt file now gets auto-generated by the powershell scripts
3. add a single-file powershell script for easier automation 
4. add CA example shader